### PR TITLE
Add nil check of transcripts's text when send action

### DIFF
--- a/Messagestore/Message/Messages/MessagesViewController.swift
+++ b/Messagestore/Message/Messages/MessagesViewController.swift
@@ -306,6 +306,8 @@ extension Message {
                 return
             }
             self.transcript(transcript, willSendTo: room, with: batch)
+            guard transcript.data?.text != nil else { return }
+            
             self.room.data?.lastTranscriptReceivedAt = .pending
             self.room.data?.lastTranscript = transcript.data
             batch.save(transcript)


### PR DESCRIPTION
It is not written that validation of blanks and line breaks should be done at the override destination

```
/// Set contents in Transcript.
/// It must be overridden.
open func transcript(_ transcript: Document<TranscriptType>, willSendTo room: Document<RoomType>, with batch: Batch) {
}
```